### PR TITLE
Exporting cycles targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ if(${BUILD_WITH_REZ})
     include(${CMAKE_CURRENT_SOURCE_DIR}/rez_deps.cmake)
 else()
     set(USE_OPENGL TRUE)
+    add_definitions(-DUSE_OPENGL)
 endif()
 
 include(external_libs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,10 @@ option(WITH_CUDA_DYNLOAD           "Dynamically load CUDA libraries at runtime" 
 mark_as_advanced(WITH_CUDA_DYNLOAD)
 
 # ====== Tangent Rez Deps
-include(${CMAKE_CURRENT_SOURCE_DIR}/rez_deps.cmake)
+option(BUILD_WITH_REZ "Build with rez" ON)
+if(${BUILD_WITH_REZ})
+    include(${CMAKE_CURRENT_SOURCE_DIR}/rez_deps.cmake)
+endif()
 
 include(external_libs)
 
@@ -121,4 +124,3 @@ include_directories(
 # Sources.
 
 add_subdirectory(src)
-add_subdirectory(third_party)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,4 +123,5 @@ include_directories(
 ###########################################################################
 # Sources.
 
+add_subdirectory(third_party)
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ mark_as_advanced(WITH_CUDA_DYNLOAD)
 option(BUILD_WITH_REZ "Build with rez" ON)
 if(${BUILD_WITH_REZ})
     include(${CMAKE_CURRENT_SOURCE_DIR}/rez_deps.cmake)
+else()
+    set(USE_OPENGL TRUE)
 endif()
 
 include(external_libs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -390,3 +390,55 @@ endif()
 if(NOT WITH_BLENDER AND WITH_CYCLES_STANDALONE)
   delayed_do_install(${CMAKE_BINARY_DIR}/bin)
 endif()
+
+#
+# Top level Cycles interface with all definitions
+#
+
+add_library(Cycles INTERFACE)
+
+target_include_directories(Cycles
+        INTERFACE
+        $<BUILD_INTERFACE:.>
+        $<INSTALL_INTERFACE:include>
+        )
+
+target_link_libraries(Cycles
+        INTERFACE
+        extern_sky
+        extern_cuew
+        extern_clew
+        cycles_bvh
+        cycles_render
+        cycles_util
+        cycles_device
+        cycles_subd
+        cycles_kernel
+        cycles_kernel_osl
+        )
+
+# create target export and install actual targets
+install(TARGETS
+        extern_sky
+        extern_cuew
+        extern_clew
+        cycles_bvh
+        cycles_render
+        cycles_util
+        cycles_device
+        cycles_subd
+        cycles_kernel
+        cycles_kernel_osl
+        Cycles
+        EXPORT CyclesTargets
+        )
+
+install(EXPORT CyclesTargets
+        FILE CyclesTargets.cmake
+        NAMESPACE Cycles::
+        DESTINATION lib/cmake
+        )
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(cmake/CyclesConfig.cmake.in CyclesConfig.cmake INSTALL_DESTINATION lib/cmake)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CyclesConfig.cmake DESTINATION lib/cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -414,7 +414,6 @@ target_link_libraries(Cycles
         cycles_device
         cycles_subd
         cycles_kernel
-        cycles_kernel_osl
         )
 
 if(${WITH_OPENVDB})
@@ -422,13 +421,6 @@ if(${WITH_OPENVDB})
             INTERFACE
             OpenVDB::openvdb
             )
-endif()
-
-if(${WITH_OSL})
-  target_link_libraries(Cycles
-          INTERFACE
-          OSL::oslcomp
-          )
 endif()
 
 # create target export and install actual targets

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -314,7 +314,7 @@ endif()
 # Warnings
 if(CMAKE_COMPILER_IS_GNUCXX)
   ADD_CHECK_CXX_COMPILER_FLAG(CMAKE_CXX_FLAGS _has_cxxflag_float_conversion "-Werror=float-conversion")
-  ADD_CHECK_CXX_COMPILER_FLAG(CMAKE_CXX_FLAGS _has_cxxflag_double_promotion "-Werror=double-promotion")
+#  ADD_CHECK_CXX_COMPILER_FLAG(CMAKE_CXX_FLAGS _has_cxxflag_double_promotion "-Werror=double-promotion")
   ADD_CHECK_CXX_COMPILER_FLAG(CMAKE_CXX_FLAGS _has_no_error_unused_macros "-Wno-error=unused-macros")
   unset(_has_cxxflag_float_conversion)
   unset(_has_cxxflag_double_promotion)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -417,6 +417,20 @@ target_link_libraries(Cycles
         cycles_kernel_osl
         )
 
+if(${WITH_OPENVDB})
+    target_link_libraries(Cycles
+            INTERFACE
+            OpenVDB::openvdb
+            )
+endif()
+
+if(${WITH_OSL})
+  target_link_libraries(Cycles
+          INTERFACE
+          OSL::oslcomp
+          )
+endif()
+
 # create target export and install actual targets
 install(TARGETS
         extern_sky

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -436,6 +436,7 @@ install(TARGETS
         extern_sky
         extern_cuew
         extern_clew
+        extern_numaapi
         cycles_bvh
         cycles_render
         cycles_util
@@ -443,6 +444,7 @@ install(TARGETS
         cycles_subd
         cycles_kernel
         cycles_kernel_osl
+        cycles_graph
         Cycles
         EXPORT CyclesTargets
         )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -443,7 +443,6 @@ install(TARGETS
         cycles_device
         cycles_subd
         cycles_kernel
-        cycles_kernel_osl
         cycles_graph
         Cycles
         EXPORT CyclesTargets

--- a/src/cmake/CyclesConfig.cmake.in
+++ b/src/cmake/CyclesConfig.cmake.in
@@ -1,0 +1,13 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+if(@WITH_CYCLES_OSL@)
+    find_dependency(OSL)
+endif()
+
+if(@WITH_CYCLES_OPENVDB@)
+    find_dependency(OpenVDB)
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/CyclesTargets.cmake)

--- a/src/cmake/CyclesConfig.cmake.in
+++ b/src/cmake/CyclesConfig.cmake.in
@@ -2,12 +2,24 @@
 
 include(CMakeFindDependencyMacro)
 
-if(@WITH_CYCLES_OSL@)
-    find_dependency(OSL)
-endif()
-
-if(@WITH_CYCLES_OPENVDB@)
-    find_dependency(OpenVDB)
-endif()
+find_dependency(OpenVDB REQUIRED)
+find_dependency(GLEW REQUIRED)
 
 include(${CMAKE_CURRENT_LIST_DIR}/CyclesTargets.cmake)
+
+target_link_libraries(Cycles::Cycles
+    INTERFACE
+    Cycles::extern_sky
+    Cycles::extern_cuew
+    Cycles::extern_clew
+    Cycles::extern_numaapi
+    Cycles::cycles_bvh
+    Cycles::cycles_render
+    Cycles::cycles_util
+    Cycles::cycles_device
+    Cycles::cycles_subd
+    Cycles::cycles_kernel
+    Cycles::cycles_graph
+    GLEW::GLEW
+    OpenVDB::openvdb
+    )

--- a/src/cmake/macros.cmake
+++ b/src/cmake/macros.cmake
@@ -31,6 +31,9 @@ macro(cycles_add_library target library_deps)
   install(TARGETS ${target} ARCHIVE DESTINATION lib)
   install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION "include" FILES_MATCHING PATTERN "*.h")
 
+  get_directory_property(DIRECTORY_DEFINITIONS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMPILE_DEFINITIONS)
+  target_compile_definitions(${target} PUBLIC ${DIRECTORY_DEFINITIONS})
+
   # On Windows certain libraries have two sets of binaries: one for debug builds and one for
   # release builds. The root of this requirement goes into ABI, I believe, but that's outside
   # of a scope of this comment.

--- a/src/cmake/macros.cmake
+++ b/src/cmake/macros.cmake
@@ -26,7 +26,7 @@ macro(install_external_library target_ext)
 endmacro()
 
 macro(cycles_add_library target library_deps)
-  add_library(${target} ${ARGN})
+  add_library(${target} STATIC ${ARGN})
 
   install(TARGETS ${target} ARCHIVE DESTINATION lib)
   install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION "include" FILES_MATCHING PATTERN "*.h")

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -41,9 +41,12 @@ set(SRC
   util_windows.cpp
 )
 
-set(LIB
-  ${TBB_LIBRARIES}
-)
+if(CYCLES_STANDALONE_REPOSITORY)
+  message(STATUS "utils linking with numaapi")
+  set(LIB ${TBB_LIBRARIES} extern_numaapi)
+else()
+  set(LIB ${TBB_LIBRARIES})
+endif()
 
 if(WITH_CYCLES_STANDALONE)
   if(WITH_CYCLES_STANDALONE_GUI)


### PR DESCRIPTION
This PR is to export targets with a cmake configuration file. There is minimal modification of the current CMake build system, so current build shouldn't be affected.

By using this approach, building `hdCycles` is simple as:

```cmake
find_package(Cycles REQUIRED)

...

target_link_libraries(hdCycles
        PRIVATE
        usdHydra
        Cycles::Cycles
        )
```