### PR TITLE
Feature/volume motion blur

### DIFF
--- a/src/kernel/geom/geom_volume.h
+++ b/src/kernel/geom/geom_volume.h
@@ -27,6 +27,24 @@ CCL_NAMESPACE_BEGIN
 
 #ifdef __VOLUME__
 
+/* Return velocity vector transformed by up_axis and object transform */
+
+ccl_device_inline float3 volume_transform_velocity(KernelGlobals *kg,
+                                                    const ShaderData *sd,
+                                                    float3 P)
+{
+  uint up_axis = kernel_tex_fetch(__objects, sd->object).up_axis;
+
+  if(up_axis == 0){ /* Up axis Z*/
+    float z = P.z;
+    P.z = P.y;
+    P.y = z;
+  }
+
+  object_dir_transform(kg, sd, &P);
+  return P;
+}
+
 /* Return position normalized to 0..1 in mesh bounds */
 
 ccl_device_inline float3 volume_normalized_position(KernelGlobals *kg,

--- a/src/kernel/geom/geom_volume.h
+++ b/src/kernel/geom/geom_volume.h
@@ -28,14 +28,14 @@ CCL_NAMESPACE_BEGIN
 #ifdef __VOLUME__
 
 /* Return velocity vector transformed by up_axis and object transform */
-
+/*
 ccl_device_inline float3 volume_transform_velocity(KernelGlobals *kg,
                                                     const ShaderData *sd,
                                                     float3 P)
 {
   uint up_axis = kernel_tex_fetch(__objects, sd->object).up_axis;
 
-  if(up_axis == 0){ /* Up axis Z*/
+  if(up_axis == 0){ 
     float z = P.z;
     P.z = P.y;
     P.y = z;
@@ -44,6 +44,7 @@ ccl_device_inline float3 volume_transform_velocity(KernelGlobals *kg,
   object_dir_transform(kg, sd, &P);
   return P;
 }
+*/
 
 /* Return position normalized to 0..1 in mesh bounds */
 

--- a/src/kernel/kernel_shader.h
+++ b/src/kernel/kernel_shader.h
@@ -1316,15 +1316,14 @@ ccl_device_inline void shader_eval_volume(KernelGlobals *kg,
 
             /* Find velocity. */
             float3 velocity = volume_attribute_float3(kg, sd, v_desc);
-            object_dir_transform(kg, sd, &velocity);
+            velocity = volume_transform_velocity(kg, sd, velocity);
 
             /* Find advected P. */
-
             sd->P = P - (time - time_offset) * velocity_scale * velocity;
 
             /* Find advected velocity. */
             velocity = volume_attribute_float3(kg, sd, v_desc);
-            object_dir_transform(kg, sd, &velocity);
+            velocity = volume_transform_velocity(kg, sd, velocity);
 
             /* Find advected P. */
             sd->P = P - (time - time_offset) * velocity_scale * velocity;

--- a/src/kernel/kernel_shader.h
+++ b/src/kernel/kernel_shader.h
@@ -1316,14 +1316,16 @@ ccl_device_inline void shader_eval_volume(KernelGlobals *kg,
 
             /* Find velocity. */
             float3 velocity = volume_attribute_float3(kg, sd, v_desc);
-            velocity = volume_transform_velocity(kg, sd, velocity);
+            object_dir_transform(kg, sd, &velocity);
+            /*velocity = volume_transform_velocity(kg, sd, velocity);*/
 
             /* Find advected P. */
             sd->P = P - (time - time_offset) * velocity_scale * velocity;
 
             /* Find advected velocity. */
             velocity = volume_attribute_float3(kg, sd, v_desc);
-            velocity = volume_transform_velocity(kg, sd, velocity);
+            object_dir_transform(kg, sd, &velocity);
+            /*velocity = volume_transform_velocity(kg, sd, velocity);*/
 
             /* Find advected P. */
             sd->P = P - (time - time_offset) * velocity_scale * velocity;

--- a/src/kernel/kernel_shader.h
+++ b/src/kernel/kernel_shader.h
@@ -1289,6 +1289,51 @@ ccl_device_inline void shader_eval_volume(KernelGlobals *kg,
       /* todo: this is inefficient for motion blur, we should be
        * caching matrices instead of recomputing them each step */
       shader_setup_object_transforms(kg, sd, sd->time);
+
+      /* Do motion blur if motion blur is on and object has velocity field */
+      if (kernel_tex_fetch(__objects, sd->object).use_motion_blur &&
+          kernel_data.cam.shuttertime != -1.0f &&
+          kernel_tex_fetch(__objects, sd->object).velocity_scale > 0.0f) {
+      
+          AttributeDescriptor v_desc = find_attribute(kg, sd, ATTR_STD_VOLUME_VELOCITY);
+
+          if (v_desc.offset != ATTR_STD_NOT_FOUND) {
+
+            const float3 P = sd->P;
+
+            const float time_offset = kernel_data.cam.motion_position == MOTION_POSITION_CENTER ?
+                                          0.5f :
+                                          0.0f;
+            const float time = kernel_data.cam.motion_position == MOTION_POSITION_END ?
+                                   (1.0f - kernel_data.cam.shuttertime) + sd->time :
+                                   sd->time;
+            /* Velocity scale: Assume m/s as input, convert to m/(shutter duration).
+               Optional scaling parameter is for artistic control. */
+            const float velocity_scale = kernel_data.cam.inv_fps * kernel_data.cam.shuttertime *
+                                         kernel_tex_fetch(__objects, sd->object).velocity_scale;
+
+            /* Find new sampling position as mentioned in
+             * https://www.arnoldrenderer.com/research/Arnold_TOG2018.pdf */
+
+            /* Find velocity. */
+            float3 velocity = volume_attribute_float3(kg, sd, v_desc);
+            object_dir_transform(kg, sd, &velocity);
+
+            /* Find advected P. */
+
+            sd->P = P - (time - time_offset) * velocity_scale * velocity;
+
+            /* Find advected velocity. */
+            velocity = volume_attribute_float3(kg, sd, v_desc);
+            object_dir_transform(kg, sd, &velocity);
+
+            /* Find advected P. */
+            sd->P = P - (time - time_offset) * velocity_scale * velocity;
+          }
+
+      }
+
+
 #  endif
     }
 

--- a/src/kernel/kernel_shader.h
+++ b/src/kernel/kernel_shader.h
@@ -1294,11 +1294,10 @@ ccl_device_inline void shader_eval_volume(KernelGlobals *kg,
       if (kernel_tex_fetch(__objects, sd->object).use_motion_blur &&
           kernel_data.cam.shuttertime != -1.0f &&
           kernel_tex_fetch(__objects, sd->object).velocity_scale > 0.0f) {
-      
+          
           AttributeDescriptor v_desc = find_attribute(kg, sd, ATTR_STD_VOLUME_VELOCITY);
-
+          
           if (v_desc.offset != ATTR_STD_NOT_FOUND) {
-
             const float3 P = sd->P;
 
             const float time_offset = kernel_data.cam.motion_position == MOTION_POSITION_CENTER ?
@@ -1332,8 +1331,6 @@ ccl_device_inline void shader_eval_volume(KernelGlobals *kg,
           }
 
       }
-
-
 #  endif
     }
 

--- a/src/kernel/kernel_types.h
+++ b/src/kernel/kernel_types.h
@@ -1494,7 +1494,7 @@ typedef struct KernelObject {
 
   bool use_motion_blur;
   float velocity_scale;
-  uint up_axis;
+  /*uint up_axis;*/
   float cryptomatte_object;
   float cryptomatte_asset;
 

--- a/src/kernel/kernel_types.h
+++ b/src/kernel/kernel_types.h
@@ -1494,7 +1494,7 @@ typedef struct KernelObject {
 
   bool use_motion_blur;
   float velocity_scale;
-
+  uint up_axis;
   float cryptomatte_object;
   float cryptomatte_asset;
 

--- a/src/kernel/kernel_types.h
+++ b/src/kernel/kernel_types.h
@@ -626,6 +626,18 @@ enum PanoramaType {
   PANORAMA_NUM_TYPES,
 };
 
+/* Specifies an offset for the shutter's time interval. */
+enum MotionPosition {
+  /* Shutter opens at the current frame. */
+  MOTION_POSITION_START = 0,
+  /* Shutter is fully open at the current frame. */
+  MOTION_POSITION_CENTER = 1,
+  /* Shutter closes at the current frame. */
+  MOTION_POSITION_END = 2,
+
+  MOTION_NUM_POSITIONS,
+};
+
 /* Differential */
 
 typedef struct differential3 {
@@ -1147,6 +1159,8 @@ typedef struct KernelCamera {
 
   /* motion blur */
   float shuttertime;
+  int motion_position;
+  float inv_fps;
   int num_motion_steps, have_perspective_motion;
 
   /* clipping */
@@ -1477,6 +1491,9 @@ typedef struct KernelObject {
   uint patch_map_offset;
   uint attribute_map_offset;
   uint motion_offset;
+
+  bool use_motion_blur;
+  float velocity_scale;
 
   float cryptomatte_object;
   float cryptomatte_asset;

--- a/src/render/attribute.cpp
+++ b/src/render/attribute.cpp
@@ -326,7 +326,7 @@ const char *Attribute::standard_name(AttributeStandard std)
     case ATTR_STD_VOLUME_TEMPERATURE:
       return "temperature";
     case ATTR_STD_VOLUME_VELOCITY:
-      return "velocity";
+      return "vel";
     case ATTR_STD_POINTINESS:
       return "pointiness";
     case ATTR_STD_RANDOM_PER_ISLAND:

--- a/src/render/camera.cpp
+++ b/src/render/camera.cpp
@@ -389,6 +389,8 @@ void Camera::update(Scene *scene)
 
   /* motion blur */
   kcam->shuttertime = (need_motion == Scene::MOTION_BLUR) ? shuttertime : -1.0f;
+  kcam->motion_position = motion_position;
+  kcam->inv_fps = 1.0f / (fps > 0.0f ? fps : 24.0f);
 
   /* type */
   kcam->type = type;

--- a/src/render/camera.h
+++ b/src/render/camera.h
@@ -43,18 +43,6 @@ class Camera : public Node {
  public:
   NODE_DECLARE
 
-  /* Specifies an offset for the shutter's time interval. */
-  enum MotionPosition {
-    /* Shutter opens at the current frame. */
-    MOTION_POSITION_START = 0,
-    /* Shutter is fully open at the current frame. */
-    MOTION_POSITION_CENTER = 1,
-    /* Shutter closes at the current frame. */
-    MOTION_POSITION_END = 2,
-
-    MOTION_NUM_POSITIONS,
-  };
-
   /* Specifies rolling shutter effect. */
   enum RollingShutterType {
     /* No rolling shutter effect. */
@@ -74,6 +62,7 @@ class Camera : public Node {
 
   /* motion blur */
   float shuttertime;
+  float fps;
   MotionPosition motion_position;
   array<float> shutter_curve;
   size_t shutter_table_offset;

--- a/src/render/geometry.cpp
+++ b/src/render/geometry.cpp
@@ -648,6 +648,20 @@ void GeometryManager::device_update_attributes(Device *device,
 
     foreach (Shader *shader, geom->used_shaders) {
       geom_attributes[i].add(shader->attributes);
+      
+      /* Add a request for volume velocity if a volume attribute is 
+      present and motion blur is on*/
+      if (scene->need_motion() == Scene::MOTION_BLUR) {
+        foreach (AttributeRequest &attr, geom_attributes[i].requests) {
+          if (attr.std == ATTR_STD_VOLUME_DENSITY || attr.std == ATTR_STD_VOLUME_COLOR
+          || attr.std == ATTR_STD_VOLUME_FLAME || attr.std == ATTR_STD_VOLUME_HEAT
+          || attr.std == ATTR_STD_VOLUME_TEMPERATURE) {
+            geom_attributes[i].add(ATTR_STD_VOLUME_VELOCITY);
+            break;
+          }
+        }
+      }
+
     }
   }
 

--- a/src/render/object.cpp
+++ b/src/render/object.cpp
@@ -465,7 +465,6 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
   kobject.random_number = random_number;
   kobject.particle_index = particle_index;
   kobject.motion_offset = 0;
-  kobject.use_motion_blur = false;
   
   if (geom->use_motion_blur) {
     state->have_motion = true;
@@ -476,11 +475,6 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
     Mesh *mesh = static_cast<Mesh *>(geom);
     if (mesh->attributes.find(ATTR_STD_MOTION_VERTEX_POSITION)) {
       flag |= SD_OBJECT_HAS_VERTEX_MOTION;
-    }
-
-    if (mesh->has_volume) {
-      kobject.velocity_scale = ob->velocity_scale;
-      kobject.up_axis = ob->up_axis;
     }
   }
 
@@ -512,7 +506,6 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
     object_motion_pass[motion_pass_offset + 1] = tfm_post;
   }
   else if (state->need_motion == Scene::MOTION_BLUR) {
-    kobject.use_motion_blur = true;
     if (ob->use_motion()) {
       kobject.motion_offset = state->motion_offset[ob->index];
 
@@ -543,7 +536,10 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
   kobject.cryptomatte_object = util_hash_to_float(hash_name);
   kobject.cryptomatte_asset = util_hash_to_float(hash_asset);
   kobject.shadow_terminator_offset = 1.0f / (1.0f - 0.5f * ob->shadow_terminator_offset);
-
+  kobject.velocity_scale = ob->velocity_scale;
+  kobject.up_axis = ob->up_axis;
+  kobject.use_motion_blur = geom->use_motion_blur;
+  
   /* Object flag. */
   if (ob->use_holdout) {
     flag |= SD_OBJECT_HOLDOUT_MASK;

--- a/src/render/object.cpp
+++ b/src/render/object.cpp
@@ -476,6 +476,10 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
     if (mesh->attributes.find(ATTR_STD_MOTION_VERTEX_POSITION)) {
       flag |= SD_OBJECT_HAS_VERTEX_MOTION;
     }
+
+    if (mesh->has_volume) {
+      kobject.velocity_scale = ob->velocity_scale;
+    }
   }
 
   if (state->need_motion == Scene::MOTION_PASS) {
@@ -516,6 +520,8 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
       state->have_motion = true;
     }
   }
+
+  kobject.use_motion_blur = ob->use_motion();
 
   /* Dupli object coords and motion info. */
   kobject.dupli_generated[0] = ob->dupli_generated[0];

--- a/src/render/object.cpp
+++ b/src/render/object.cpp
@@ -537,7 +537,7 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
   kobject.cryptomatte_asset = util_hash_to_float(hash_asset);
   kobject.shadow_terminator_offset = 1.0f / (1.0f - 0.5f * ob->shadow_terminator_offset);
   kobject.velocity_scale = ob->velocity_scale;
-  kobject.up_axis = ob->up_axis;
+  /*kobject.up_axis = ob->up_axis;*/
   kobject.use_motion_blur = geom->use_motion_blur;
   
   /* Object flag. */

--- a/src/render/object.cpp
+++ b/src/render/object.cpp
@@ -465,7 +465,8 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
   kobject.random_number = random_number;
   kobject.particle_index = particle_index;
   kobject.motion_offset = 0;
-
+  kobject.use_motion_blur = false;
+  
   if (geom->use_motion_blur) {
     state->have_motion = true;
   }
@@ -510,6 +511,7 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
     object_motion_pass[motion_pass_offset + 1] = tfm_post;
   }
   else if (state->need_motion == Scene::MOTION_BLUR) {
+    kobject.use_motion_blur = true;
     if (ob->use_motion()) {
       kobject.motion_offset = state->motion_offset[ob->index];
 
@@ -521,7 +523,6 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
     }
   }
 
-  kobject.use_motion_blur = ob->use_motion();
 
   /* Dupli object coords and motion info. */
   kobject.dupli_generated[0] = ob->dupli_generated[0];

--- a/src/render/object.cpp
+++ b/src/render/object.cpp
@@ -480,6 +480,7 @@ void ObjectManager::device_update_object_transform(UpdateObjectTransformState *s
 
     if (mesh->has_volume) {
       kobject.velocity_scale = ob->velocity_scale;
+      kobject.up_axis = ob->up_axis;
     }
   }
 

--- a/src/render/object.h
+++ b/src/render/object.h
@@ -63,7 +63,7 @@ class Object : public Node {
 
   /* This scale is applied to volumetric motion blur. */
   float velocity_scale;
-  uint up_axis;
+  /*uint up_axis;*/
 
   float3 dupli_generated;
   float2 dupli_uv;

--- a/src/render/object.h
+++ b/src/render/object.h
@@ -61,6 +61,9 @@ class Object : public Node {
   bool is_shadow_catcher;
   float shadow_terminator_offset;
 
+  /* This scale is applied to volumetric motion blur. */
+  float velocity_scale;
+
   float3 dupli_generated;
   float2 dupli_uv;
 

--- a/src/render/object.h
+++ b/src/render/object.h
@@ -63,6 +63,7 @@ class Object : public Node {
 
   /* This scale is applied to volumetric motion blur. */
   float velocity_scale;
+  uint up_axis;
 
   float3 dupli_generated;
   float2 dupli_uv;


### PR DESCRIPTION
#### Summary

Added support for eularian deformation motion blur for volumes. 

#### Change Log 

- Moved the MotionPosition enum from camera to a kernel_types.h to be able to use in kernel 
- Added a new function to *geom_volume.h* to support different up_axis configurations 
- Added velocity_scale field to ccl::Object and kernel object to scale volume motion blur 
- Added an fps field to Camera 

#### Testing 

Please see the hdCycles PR: [https://github.com/tangent-opensource/hdcycles/pull/75](https://github.com/tangent-opensource/hdcycles/pull/75)