### PR TITLE
Adding the option to set the filter when adding a pass.

### DIFF
--- a/src/render/film.cpp
+++ b/src/render/film.cpp
@@ -38,7 +38,7 @@ static bool compare_pass_order(const Pass &a, const Pass &b)
   return (a.components > b.components);
 }
 
-void Pass::add(PassType type, vector<Pass> &passes, const char *name)
+void Pass::add(PassType type, vector<Pass> &passes, const char *name, bool filter)
 {
   for (size_t i = 0; i < passes.size(); i++) {
     if (passes[i].type != type) {
@@ -76,7 +76,7 @@ void Pass::add(PassType type, vector<Pass> &passes, const char *name)
   Pass pass;
 
   pass.type = type;
-  pass.filter = true;
+  pass.filter = filter;
   pass.exposure = false;
   pass.divide_type = PASS_NONE;
   if (name) {

--- a/src/render/film.h
+++ b/src/render/film.h
@@ -47,7 +47,7 @@ class Pass {
   PassType divide_type;
   string name;
 
-  static void add(PassType type, vector<Pass> &passes, const char *name = NULL);
+  static void add(PassType type, vector<Pass> &passes, const char *name = NULL, bool filter = true);
   static bool equals(const vector<Pass> &A, const vector<Pass> &B);
   static bool contains(const vector<Pass> &passes, PassType);
 };


### PR DESCRIPTION
Adding the option to set the filter when adding a pass. Defaults to filter as true like normal, and internal overrides will still override this option for eg. depth/IDs. This is good for when creating a custom AOV of color or value and you want to not have a filter to it, like P/Pref/etc.