### PR TITLE
adding rtc namespace open

### DIFF
--- a/src/bvh/bvh_embree.h
+++ b/src/bvh/bvh_embree.h
@@ -29,6 +29,7 @@
 #  include "util/util_types.h"
 #  include "util/util_vector.h"
 
+RTC_NAMESPACE_OPEN
 CCL_NAMESPACE_BEGIN
 
 class Geometry;

--- a/src/kernel/bvh/bvh_embree.h
+++ b/src/kernel/bvh/bvh_embree.h
@@ -25,6 +25,7 @@
 
 #include "util/util_vector.h"
 
+RTC_NAMESPACE_OPEN
 CCL_NAMESPACE_BEGIN
 
 struct CCLIntersectContext {

--- a/src/kernel/kernel_types.h
+++ b/src/kernel/kernel_types.h
@@ -21,6 +21,7 @@
 #  include <embree3/rtcore.h>
 #  include <embree3/rtcore_scene.h>
 #  define __EMBREE__
+RTC_NAMESPACE_OPEN
 #endif
 
 #include "kernel/kernel_math.h"


### PR DESCRIPTION
In certain ecosystems embree classes are being put under namespace. Adding `RTC_NAMESPACE_OPEN`, that is equivalent to `using namespace  <embree_namespace>`, allows compilation under different ecosystems such as Houdini:

https://www.sidefx.com/docs/hdk/rtcore__config_8h_source.html

Another option would be go through all rtc classes and prefix them with `RTC_NAMESPACE::`.