### PR TITLE
Revert "adding rtc namesapce"

### DIFF
--- a/src/kernel/kernel_types.h
+++ b/src/kernel/kernel_types.h
@@ -21,7 +21,6 @@
 #  include <embree3/rtcore.h>
 #  include <embree3/rtcore_scene.h>
 #  define __EMBREE__
-RTC_NAMESPACE_OPEN
 #endif
 
 #include "kernel/kernel_math.h"


### PR DESCRIPTION
Reverts tangent-opensource/cycles#15

Accidentally merged this too early. We need to use `RTC_NAMESPACE_USE`, not `RTC_NAMESPACE_OPEN`