### PR TITLE
Fixed a potential dead lock. Mutex order was reversed.

### DIFF
--- a/src/render/session.cpp
+++ b/src/render/session.cpp
@@ -346,8 +346,8 @@ void Session::run_gpu()
 
 void Session::reset_cpu(BufferParams &buffer_params, int samples)
 {
-  thread_scoped_lock reset_lock(delayed_reset.mutex);
   thread_scoped_lock pause_lock(pause_mutex);
+  thread_scoped_lock reset_lock(delayed_reset.mutex);
 
   display_outdated = true;
   reset_time = time_dt();


### PR DESCRIPTION
This is the dead lock I ran into when testing. Thread sanitizer also reported these locks as dangerous.