### PR TITLE
Exposing display lock in cycles session

### DIFF
--- a/src/render/session.cpp
+++ b/src/render/session.cpp
@@ -382,14 +382,6 @@ bool Session::draw_cpu(BufferParams &buffer_params, DeviceDrawParams &draw_param
   return false;
 }
 
-void Session::acquire_display() {
-  display_mutex.lock();
-}
-
-void Session::release_display() {
-  display_mutex.unlock();
-}
-
 bool Session::acquire_tile(RenderTile &rtile, Device *tile_device, uint tile_types)
 {
   if (progress.get_cancel()) {
@@ -1340,6 +1332,10 @@ void Session::collect_statistics(RenderStats *render_stats)
   if (params.use_profiling && (params.device.type == DEVICE_CPU)) {
     render_stats->collect_profiling(scene, profiler);
   }
+}
+
+thread_scoped_lock Session::acquire_display_lock() {
+  return thread_scoped_lock(display_mutex);
 }
 
 int Session::get_max_closure_count()

--- a/src/render/session.cpp
+++ b/src/render/session.cpp
@@ -382,6 +382,14 @@ bool Session::draw_cpu(BufferParams &buffer_params, DeviceDrawParams &draw_param
   return false;
 }
 
+void Session::acquire_display() {
+  display_mutex.lock();
+}
+
+void Session::release_display() {
+  display_mutex.unlock();
+}
+
 bool Session::acquire_tile(RenderTile &rtile, Device *tile_device, uint tile_types)
 {
   if (progress.get_cancel()) {

--- a/src/render/session.h
+++ b/src/render/session.h
@@ -167,6 +167,9 @@ class Session {
 
   void collect_statistics(RenderStats *stats);
 
+  void acquire_display();
+  void release_display();
+
  protected:
   struct DelayedReset {
     thread_mutex mutex;

--- a/src/render/session.h
+++ b/src/render/session.h
@@ -167,8 +167,7 @@ class Session {
 
   void collect_statistics(RenderStats *stats);
 
-  void acquire_display();
-  void release_display();
+  thread_scoped_lock acquire_display_lock();
 
  protected:
   struct DelayedReset {


### PR DESCRIPTION
Allowing the user of `Session` to control the display mutex, this is necessary as HdCycles reads from the display buffer when a resize (`reset`) has been scheduled to happen in the session thread. 

I tried returning the `thread_scoped_lock` rather than directly lock the mutex, but experienced a GL-related crash in Houdini which I was not able to reproduce with the current version. 