### PR TITLE
Moving element_size method to Geometry

### DIFF
--- a/src/render/attribute.cpp
+++ b/src/render/attribute.cpp
@@ -158,78 +158,7 @@ size_t Attribute::element_size(Geometry *geom, AttributePrimitive prim) const
     return buffer.size() / data_sizeof();
   }
 
-  size_t size = 0;
-
-  switch (element) {
-    case ATTR_ELEMENT_OBJECT:
-    case ATTR_ELEMENT_MESH:
-    case ATTR_ELEMENT_VOXEL:
-      size = 1;
-      break;
-    case ATTR_ELEMENT_VERTEX:
-      if (geom->type == Geometry::MESH) {
-        Mesh *mesh = static_cast<Mesh *>(geom);
-        size = mesh->verts.size() + mesh->num_ngons;
-        if (prim == ATTR_PRIM_SUBD) {
-          size -= mesh->num_subd_verts;
-        }
-      }
-      break;
-    case ATTR_ELEMENT_VERTEX_MOTION:
-      if (geom->type == Geometry::MESH) {
-        Mesh *mesh = static_cast<Mesh *>(geom);
-        size = (mesh->verts.size() + mesh->num_ngons) * (mesh->motion_steps - 1);
-        if (prim == ATTR_PRIM_SUBD) {
-          size -= mesh->num_subd_verts * (mesh->motion_steps - 1);
-        }
-      }
-      break;
-    case ATTR_ELEMENT_FACE:
-      if (geom->type == Geometry::MESH) {
-        Mesh *mesh = static_cast<Mesh *>(geom);
-        if (prim == ATTR_PRIM_GEOMETRY) {
-          size = mesh->num_triangles();
-        }
-        else {
-          size = mesh->subd_faces.size() + mesh->num_ngons;
-        }
-      }
-      break;
-    case ATTR_ELEMENT_CORNER:
-    case ATTR_ELEMENT_CORNER_BYTE:
-      if (geom->type == Geometry::MESH) {
-        Mesh *mesh = static_cast<Mesh *>(geom);
-        if (prim == ATTR_PRIM_GEOMETRY) {
-          size = mesh->num_triangles() * 3;
-        }
-        else {
-          size = mesh->subd_face_corners.size() + mesh->num_ngons;
-        }
-      }
-      break;
-    case ATTR_ELEMENT_CURVE:
-      if (geom->type == Geometry::HAIR) {
-        Hair *hair = static_cast<Hair *>(geom);
-        size = hair->num_curves();
-      }
-      break;
-    case ATTR_ELEMENT_CURVE_KEY:
-      if (geom->type == Geometry::HAIR) {
-        Hair *hair = static_cast<Hair *>(geom);
-        size = hair->curve_keys.size();
-      }
-      break;
-    case ATTR_ELEMENT_CURVE_KEY_MOTION:
-      if (geom->type == Geometry::HAIR) {
-        Hair *hair = static_cast<Hair *>(geom);
-        size = hair->curve_keys.size() * (hair->motion_steps - 1);
-      }
-      break;
-    default:
-      break;
-  }
-
-  return size;
+  return geom->element_size(element, prim);
 }
 
 size_t Attribute::buffer_size(Geometry *geom, AttributePrimitive prim) const

--- a/src/render/geometry.cpp
+++ b/src/render/geometry.cpp
@@ -257,10 +257,6 @@ void Geometry::tag_update(Scene *scene, bool rebuild)
   scene->object_manager->need_update = true;
 }
 
-size_t Geometry::element_size(AttributeElement element) const {
-  return element_size(element, attributes.prim);
-}
-
 size_t Geometry::element_size(AttributeElement element, AttributePrimitive prim) const {
   size_t size = 0;
 

--- a/src/render/geometry.cpp
+++ b/src/render/geometry.cpp
@@ -257,6 +257,10 @@ void Geometry::tag_update(Scene *scene, bool rebuild)
   scene->object_manager->need_update = true;
 }
 
+size_t Geometry::element_size(AttributeElement element) const {
+  return element_size(element, attributes.prim);
+}
+
 size_t Geometry::element_size(AttributeElement element, AttributePrimitive prim) const {
   size_t size = 0;
 

--- a/src/render/geometry.cpp
+++ b/src/render/geometry.cpp
@@ -257,6 +257,81 @@ void Geometry::tag_update(Scene *scene, bool rebuild)
   scene->object_manager->need_update = true;
 }
 
+size_t Geometry::element_size(AttributeElement element, AttributePrimitive prim) const {
+  size_t size = 0;
+
+  switch (element) {
+    case ATTR_ELEMENT_OBJECT:
+    case ATTR_ELEMENT_MESH:
+    case ATTR_ELEMENT_VOXEL:
+      size = 1;
+      break;
+    case ATTR_ELEMENT_VERTEX:
+      if (type == Geometry::MESH) {
+        const Mesh *mesh = static_cast<const Mesh *>(this);
+        size = mesh->verts.size() + mesh->num_ngons;
+        if (prim == ATTR_PRIM_SUBD) {
+          size -= mesh->num_subd_verts;
+        }
+      }
+      break;
+    case ATTR_ELEMENT_VERTEX_MOTION:
+      if (type == Geometry::MESH) {
+        const Mesh *mesh = static_cast<const Mesh *>(this);
+        size = (mesh->verts.size() + mesh->num_ngons) * (mesh->motion_steps - 1);
+        if (prim == ATTR_PRIM_SUBD) {
+          size -= mesh->num_subd_verts * (mesh->motion_steps - 1);
+        }
+      }
+      break;
+    case ATTR_ELEMENT_FACE:
+      if (type == Geometry::MESH) {
+        const Mesh *mesh = static_cast<const Mesh *>(this);
+        if (prim == ATTR_PRIM_GEOMETRY) {
+          size = mesh->num_triangles();
+        }
+        else {
+          size = mesh->subd_faces.size() + mesh->num_ngons;
+        }
+      }
+      break;
+    case ATTR_ELEMENT_CORNER:
+    case ATTR_ELEMENT_CORNER_BYTE:
+      if (type == Geometry::MESH) {
+        const Mesh *mesh = static_cast<const Mesh *>(this);
+        if (prim == ATTR_PRIM_GEOMETRY) {
+          size = mesh->num_triangles() * 3;
+        }
+        else {
+          size = mesh->subd_face_corners.size() + mesh->num_ngons;
+        }
+      }
+      break;
+    case ATTR_ELEMENT_CURVE:
+      if (type == Geometry::HAIR) {
+        const Hair *hair = static_cast<const Hair *>(this);
+        size = hair->num_curves();
+      }
+      break;
+    case ATTR_ELEMENT_CURVE_KEY:
+      if (type == Geometry::HAIR) {
+        const Hair *hair = static_cast<const Hair *>(this);
+        size = hair->curve_keys.size();
+      }
+      break;
+    case ATTR_ELEMENT_CURVE_KEY_MOTION:
+      if (type == Geometry::HAIR) {
+        const Hair *hair = static_cast<const Hair *>(this);
+        size = hair->curve_keys.size() * (hair->motion_steps - 1);
+      }
+      break;
+    default:
+      break;
+  }
+
+  return size;
+}
+
 /* Geometry Manager */
 
 GeometryManager::GeometryManager()

--- a/src/render/geometry.h
+++ b/src/render/geometry.h
@@ -136,6 +136,8 @@ class Geometry : public Node {
   bool has_motion_blur() const;
   bool has_voxel_attributes() const;
 
+  size_t element_size(AttributeElement element, AttributePrimitive prim) const;
+
   /* Updates */
   void tag_update(Scene *scene, bool rebuild);
 };

--- a/src/render/geometry.h
+++ b/src/render/geometry.h
@@ -136,7 +136,6 @@ class Geometry : public Node {
   bool has_motion_blur() const;
   bool has_voxel_attributes() const;
 
-  virtual size_t element_size(AttributeElement element) const;
   size_t element_size(AttributeElement element, AttributePrimitive prim) const;
 
   /* Updates */

--- a/src/render/geometry.h
+++ b/src/render/geometry.h
@@ -136,6 +136,7 @@ class Geometry : public Node {
   bool has_motion_blur() const;
   bool has_voxel_attributes() const;
 
+  virtual size_t element_size(AttributeElement element) const;
   size_t element_size(AttributeElement element, AttributePrimitive prim) const;
 
   /* Updates */

--- a/src/render/mesh.h
+++ b/src/render/mesh.h
@@ -145,11 +145,6 @@ class Mesh : public Geometry {
 
   SubdParams *subd_params;
 
-  size_t element_size(AttributeElement element) const final {
-    const AttributeSet &attrs = (subdivision_type == SUBDIVISION_NONE) ? attributes : subd_attributes;
-    return Geometry::element_size(element, attrs.prim);
-  }
-
   AttributeSet subd_attributes;
 
   PackedPatchTable *patch_table;

--- a/src/render/mesh.h
+++ b/src/render/mesh.h
@@ -145,6 +145,11 @@ class Mesh : public Geometry {
 
   SubdParams *subd_params;
 
+  size_t element_size(AttributeElement element) const final {
+    const AttributeSet &attrs = (subdivision_type == SUBDIVISION_NONE) ? attributes : subd_attributes;
+    return Geometry::element_size(element, attrs.prim);
+  }
+
   AttributeSet subd_attributes;
 
   PackedPatchTable *patch_table;


### PR DESCRIPTION
It looks a bit strange to me that I can't do early check of element size on geometry. I must construct an instance of Attribute to find out it's size. 

Therefore, I moved the implementation of `element_size` from `Attribute` to `Geometry`, this way we can do early check of the element size. `Attribute::element_size` calls the implementation from `Geometry`. 