### PR TITLE
Initialize camera members

### DIFF
--- a/src/render/camera.cpp
+++ b/src/render/camera.cpp
@@ -153,22 +153,22 @@ NODE_DEFINE(Camera)
 
 Camera::Camera() : Node(node_type)
 {
-  shuttertime = 1.f;
-  fps = 24.f;
+  shuttertime = 1.0f;
+  fps = 24.0f;
   motion_position = MOTION_POSITION_CENTER;
 
   shutter_table_offset = TABLE_OFFSET_INVALID;
 
   rolling_shutter_type = ROLLING_SHUTTER_NONE;
-  rolling_shutter_duration = 0.f;
+  rolling_shutter_duration = 0.0f;
 
-  focaldistance = 0.f;
-  aperturesize = 0.f;
+  focaldistance = 0.0f;
+  aperturesize = 0.0f;
   blades = 0;
-  bladesrotation = 0.f;
+  bladesrotation = 0.0f;
 
   type = CAMERA_PERSPECTIVE;
-  fov = M_PI_F * 0.25;
+  fov = 0.25f;
 
   nearclip = 0.01f;
   farclip = 100000.f;

--- a/src/render/camera.cpp
+++ b/src/render/camera.cpp
@@ -153,7 +153,25 @@ NODE_DEFINE(Camera)
 
 Camera::Camera() : Node(node_type)
 {
+  shuttertime = 1.f;
+  fps = 24.f;
+  motion_position = MOTION_POSITION_CENTER;
+
   shutter_table_offset = TABLE_OFFSET_INVALID;
+
+  rolling_shutter_type = ROLLING_SHUTTER_NONE;
+  rolling_shutter_duration = 0.f;
+
+  focaldistance = 0.f;
+  aperturesize = 0.f;
+  blades = 0;
+  bladesrotation = 0.f;
+
+  type = CAMERA_PERSPECTIVE;
+  fov = M_PI_F * 0.25;
+
+  nearclip = 0.01f;
+  farclip = 100000.f;
 
   width = 1024;
   height = 512;


### PR DESCRIPTION
Some of the members of `ccl::Camera` are left uninitialized. Due to the current synchronization logic in HdCycles this sometimes causes problem. It seems more reasonable to fix it here.

If you can double check that I initialized all the required variables it would be great, some are dependent (on types/other members) and thus are left uninitialized. 