### PR TITLE
clew and cuew dl dependency fix for linux

### DIFF
--- a/third_party/clew/CMakeLists.txt
+++ b/third_party/clew/CMakeLists.txt
@@ -14,3 +14,7 @@ include_directories(
 
 add_library(extern_clew ${SRC} ${SRC_HEADERS})
 install_external_library(extern_clew)
+
+if(UNIX)
+	target_link_libraries(extern_clew dl)
+endif()

--- a/third_party/cuew/CMakeLists.txt
+++ b/third_party/cuew/CMakeLists.txt
@@ -13,3 +13,7 @@ include_directories(
 
 add_library(extern_cuew ${SRC} ${SRC_HEADERS})
 install_external_library(extern_cuew)
+
+if(UNIX)
+	target_link_libraries(extern_cuew dl)
+endif()


### PR DESCRIPTION
Missing dl dependency causes fail while linking with static libs