### PR TITLE
Motion blur normals for PointClouds

### DIFF
--- a/src/kernel/geom/geom_motion_point.h
+++ b/src/kernel/geom/geom_motion_point.h
@@ -45,13 +45,13 @@ ccl_device_inline int find_attribute_point_motion(KernelGlobals *kg,
 }
 
 ccl_device_inline float4 motion_point_attribute_for_step(KernelGlobals *kg,
-                                               int offset,
-                                               int numkeys,
-                                               int numsteps,
-                                               int step,
-                                               int prim,
-                                               int n_points_attrs,
-                                               int attr)
+                                                         int offset,
+                                                         int numkeys,
+                                                         int numsteps,
+                                                         int step,
+                                                         int prim,
+                                                         int n_points_attrs,
+                                                         int attr)
 {
   if (step == numsteps) {
     /* center step: regular key location */
@@ -69,8 +69,13 @@ ccl_device_inline float4 motion_point_attribute_for_step(KernelGlobals *kg,
 }
 
 /* return 2 point key locations */
-ccl_device_inline float4
-motion_point(KernelGlobals *kg, int object, int prim, float time, int n_points_attrs, uint id_attr, int attr)
+ccl_device_inline float4 motion_point_attribute(KernelGlobals *kg,
+                                                int object,
+                                                int prim,
+                                                float time,
+                                                int n_points_attrs,
+                                                uint id_attr,
+                                                int attr)
 {
   /* get motion info */
   int numsteps, numkeys;
@@ -87,7 +92,8 @@ motion_point(KernelGlobals *kg, int object, int prim, float time, int n_points_a
   kernel_assert(offset != ATTR_STD_NOT_FOUND);
 
   /* fetch key coordinates */
-  float4 point_attr = motion_point_attribute_for_step(kg, offset, numkeys, numsteps, step, prim, n_points_attrs, attr);
+  float4 point_attr = motion_point_attribute_for_step(
+      kg, offset, numkeys, numsteps, step, prim, n_points_attrs, attr);
   float4 next_point_attr = motion_point_attribute_for_step(
       kg, offset, numkeys, numsteps, step + 1, prim, n_points_attrs, attr);
 

--- a/src/kernel/geom/geom_motion_point.h
+++ b/src/kernel/geom/geom_motion_point.h
@@ -44,17 +44,18 @@ ccl_device_inline int find_attribute_point_motion(KernelGlobals *kg,
   return (attr_map.y == ATTR_ELEMENT_NONE) ? (int)ATTR_STD_NOT_FOUND : (int)attr_map.z;
 }
 
-ccl_device_inline float4 motion_point_for_step(KernelGlobals *kg,
+ccl_device_inline float4 motion_point_attribute_for_step(KernelGlobals *kg,
                                                int offset,
                                                int numkeys,
                                                int numsteps,
                                                int step,
                                                int prim,
-                                               int n_points_attrs)
+                                               int n_points_attrs,
+                                               int attr)
 {
   if (step == numsteps) {
     /* center step: regular key location */
-    return kernel_tex_fetch(__points, prim * n_points_attrs);
+    return kernel_tex_fetch(__points, prim * n_points_attrs + attr);
   }
   else {
     /* center step is not stored in this array */
@@ -69,7 +70,7 @@ ccl_device_inline float4 motion_point_for_step(KernelGlobals *kg,
 
 /* return 2 point key locations */
 ccl_device_inline float4
-motion_point(KernelGlobals *kg, int object, int prim, float time, int n_points_attrs)
+motion_point(KernelGlobals *kg, int object, int prim, float time, int n_points_attrs, uint id_attr, int attr)
 {
   /* get motion info */
   int numsteps, numkeys;
@@ -82,16 +83,16 @@ motion_point(KernelGlobals *kg, int object, int prim, float time, int n_points_a
 
   /* find attribute */
   AttributeElement elem;
-  int offset = find_attribute_point_motion(kg, object, ATTR_STD_MOTION_VERTEX_POSITION, &elem);
+  int offset = find_attribute_point_motion(kg, object, id_attr, &elem);
   kernel_assert(offset != ATTR_STD_NOT_FOUND);
 
   /* fetch key coordinates */
-  float4 point = motion_point_for_step(kg, offset, numkeys, numsteps, step, prim, n_points_attrs);
-  float4 next_point = motion_point_for_step(
-      kg, offset, numkeys, numsteps, step + 1, prim, n_points_attrs);
+  float4 point_attr = motion_point_attribute_for_step(kg, offset, numkeys, numsteps, step, prim, n_points_attrs, attr);
+  float4 next_point_attr = motion_point_attribute_for_step(
+      kg, offset, numkeys, numsteps, step + 1, prim, n_points_attrs, attr);
 
   /* interpolate between steps */
-  return (1.0f - t) * point + t * next_point;
+  return (1.0f - t) * point_attr + t * next_point_attr;
 }
 
 #endif

--- a/src/kernel/geom/geom_point_intersect.h
+++ b/src/kernel/geom/geom_point_intersect.h
@@ -256,7 +256,7 @@ ccl_device_inline void point_shader_setup(KernelGlobals *kg,
     }
     else {
       sd->Ng = float4_to_float3(motion_point_attribute(
-          kg, sd->object, sd->prim, sd->time, n_attrs, ATTR_STD_MOTION_VERTEX_POSITION, 1));
+          kg, sd->object, sd->prim, sd->time, n_attrs, ATTR_STD_MOTION_VERTEX_NORMAL, 1));
     }
   }
   if (isect->object != OBJECT_NONE) {

--- a/src/kernel/geom/geom_point_intersect.h
+++ b/src/kernel/geom/geom_point_intersect.h
@@ -148,12 +148,14 @@ ccl_device_forceinline bool point_intersect(KernelGlobals *kg,
                           2 :
                           1;
 
+  const int fobject = (object == OBJECT_NONE) ? kernel_tex_fetch(__prim_object, prim_addr) :
+                                                object;
   if (!is_motion) {
     point = kernel_tex_fetch(__points, prim * n_attrs);
-  } else {
-    const int fobject = (object == OBJECT_NONE) ? kernel_tex_fetch(__prim_object, prim_addr) :
-                                                  object;
-    point = motion_point_attribute(kg, fobject, prim, time, n_attrs, ATTR_STD_MOTION_VERTEX_POSITION, 0);
+  }
+  else {
+    point = motion_point_attribute(
+        kg, fobject, prim, time, n_attrs, ATTR_STD_MOTION_VERTEX_POSITION, 0);
   }
 
   float t = isect->t;
@@ -169,10 +171,12 @@ ccl_device_forceinline bool point_intersect(KernelGlobals *kg,
     float3 normal;
     if (!is_motion) {
       normal = float4_to_float3(kernel_tex_fetch(__points, prim * n_attrs + 1));
-    } else {
-      normal = motion_point_attribute(kg, fobject, prim, time, n_attrs, ATTR_STD_MOTION_VERTEX_NORMAL, 1);
     }
-    
+    else {
+      normal = float4_to_float3(motion_point_attribute(
+          kg, fobject, prim, time, n_attrs, ATTR_STD_MOTION_VERTEX_NORMAL, 1));
+    }
+
     ret_test = point_intersect_test_disc_oriented(point, P, normal, dir, &t);
   }
   if (!ret_test) {
@@ -221,8 +225,10 @@ ccl_device_inline void point_shader_setup(KernelGlobals *kg,
   float3 center;
   if (!is_motion) {
     center = float4_to_float3(kernel_tex_fetch(__points, sd->prim * n_attrs));
-  } else {
-    center = float4_to_float3(motion_point_attribute(kg, sd->object, sd->prim, sd->time, n_attrs, ATTR_STD_MOTION_VERTEX_POSITION, 0));
+  }
+  else {
+    center = float4_to_float3(motion_point_attribute(
+        kg, sd->object, sd->prim, sd->time, n_attrs, ATTR_STD_MOTION_VERTEX_POSITION, 0));
   }
 
   if (isect->object != OBJECT_NONE) {
@@ -247,8 +253,10 @@ ccl_device_inline void point_shader_setup(KernelGlobals *kg,
     /* todo: This buffer should be obtained from Embree */
     if (!is_motion) {
       sd->Ng = float4_to_float3(kernel_tex_fetch(__points, sd->prim * n_attrs + 1));
-    } else {
-      sd->Ng = float4_to_float3(motion_point_attribute(kg, sd->object, sd->prim, sd->time, n_attrs, ATTR_STD_MOTION_VERTEX_POSITION, 1));
+    }
+    else {
+      sd->Ng = float4_to_float3(motion_point_attribute(
+          kg, sd->object, sd->prim, sd->time, n_attrs, ATTR_STD_MOTION_VERTEX_POSITION, 1));
     }
   }
   if (isect->object != OBJECT_NONE) {

--- a/src/kernel/geom/geom_point_intersect.h
+++ b/src/kernel/geom/geom_point_intersect.h
@@ -150,11 +150,10 @@ ccl_device_forceinline bool point_intersect(KernelGlobals *kg,
 
   if (!is_motion) {
     point = kernel_tex_fetch(__points, prim * n_attrs);
-  }
-  else {
+  } else {
     const int fobject = (object == OBJECT_NONE) ? kernel_tex_fetch(__prim_object, prim_addr) :
                                                   object;
-    point = motion_point(kg, fobject, prim, time, n_attrs);
+    point = motion_point_attribute(kg, fobject, prim, time, n_attrs, ATTR_STD_MOTION_VERTEX_POSITION, 0);
   }
 
   float t = isect->t;
@@ -167,7 +166,13 @@ ccl_device_forceinline bool point_intersect(KernelGlobals *kg,
     ret_test = point_intersect_test_disc(point, P, dir, &t);
   }
   else if (type == PRIMITIVE_POINT_DISC_ORIENTED || type == PRIMITIVE_MOTION_POINT_DISC_ORIENTED) {
-    const float3 normal = float4_to_float3(kernel_tex_fetch(__points, prim * n_attrs + 1));
+    float3 normal;
+    if (!is_motion) {
+      normal = float4_to_float3(kernel_tex_fetch(__points, prim * n_attrs + 1));
+    } else {
+      normal = motion_point_attribute(kg, fobject, prim, time, n_attrs, ATTR_STD_MOTION_VERTEX_NORMAL, 1);
+    }
+    
     ret_test = point_intersect_test_disc_oriented(point, P, normal, dir, &t);
   }
   if (!ret_test) {
@@ -197,6 +202,8 @@ ccl_device_inline void point_shader_setup(KernelGlobals *kg,
                                           const Intersection *isect,
                                           const Ray *ray)
 {
+  const bool is_motion = isect->type & PRIMITIVE_ALL_MOTION;
+
   sd->shader = kernel_tex_fetch(__points_shader, sd->prim);
   sd->P = ray->P + ray->D * isect->t;
 
@@ -211,9 +218,12 @@ ccl_device_inline void point_shader_setup(KernelGlobals *kg,
                        sd->type == PRIMITIVE_MOTION_POINT_DISC_ORIENTED) ?
                           2 :
                           1;
-  float3 center = float4_to_float3((isect->type & PRIMITIVE_ALL_MOTION) ?
-                                       motion_point(kg, sd->object, sd->prim, sd->time, n_attrs) :
-                                       kernel_tex_fetch(__points, sd->prim * n_attrs));
+  float3 center;
+  if (!is_motion) {
+    center = float4_to_float3(kernel_tex_fetch(__points, sd->prim * n_attrs));
+  } else {
+    center = float4_to_float3(motion_point_attribute(kg, sd->object, sd->prim, sd->time, n_attrs, ATTR_STD_MOTION_VERTEX_POSITION, 0));
+  }
 
   if (isect->object != OBJECT_NONE) {
 #  ifdef __OBJECT_MOTION__
@@ -235,7 +245,11 @@ ccl_device_inline void point_shader_setup(KernelGlobals *kg,
   else if (sd->type == PRIMITIVE_POINT_DISC_ORIENTED ||
            sd->type == PRIMITIVE_MOTION_POINT_DISC_ORIENTED) {
     /* todo: This buffer should be obtained from Embree */
-    sd->Ng = float4_to_float3(kernel_tex_fetch(__points, sd->prim * n_attrs + 1));
+    if (!is_motion) {
+      sd->Ng = float4_to_float3(kernel_tex_fetch(__points, sd->prim * n_attrs + 1));
+    } else {
+      sd->Ng = float4_to_float3(motion_point_attribute(kg, sd->object, sd->prim, sd->time, n_attrs, ATTR_STD_MOTION_VERTEX_POSITION, 1));
+    }
   }
   if (isect->object != OBJECT_NONE) {
     object_inverse_normal_transform(kg, sd, &sd->Ng);

--- a/src/render/geometry.cpp
+++ b/src/render/geometry.cpp
@@ -428,6 +428,8 @@ TypeDesc Geometry::standard_type(AttributeStandard std) const {
         return TypeDesc::TypePoint;
       case ATTR_STD_MOTION_VERTEX_POSITION:
         return TypeDesc::TypePoint;
+      case ATTR_STD_MOTION_VERTEX_NORMAL:
+        return TypeDesc::TypePoint;
       case ATTR_STD_VERTEX_VELOCITY:
         return TypeDesc::TypePoint;
       case ATTR_STD_VERTEX_ACCELERATION:

--- a/src/render/geometry.cpp
+++ b/src/render/geometry.cpp
@@ -343,7 +343,8 @@ size_t Geometry::element_size(AttributeElement element, AttributePrimitive prim)
   return size;
 }
 
-TypeDesc Geometry::standard_type(AttributeStandard std) const {
+TypeDesc Geometry::standard_type(AttributeStandard std) const
+{
   if (type == Geometry::MESH) {
     switch (std) {
       case ATTR_STD_VERTEX_NORMAL:
@@ -429,7 +430,7 @@ TypeDesc Geometry::standard_type(AttributeStandard std) const {
       case ATTR_STD_MOTION_VERTEX_POSITION:
         return TypeDesc::TypePoint;
       case ATTR_STD_MOTION_VERTEX_NORMAL:
-        return TypeDesc::TypePoint;
+        return TypeDesc::TypeNormal;
       case ATTR_STD_VERTEX_VELOCITY:
         return TypeDesc::TypePoint;
       case ATTR_STD_VERTEX_ACCELERATION:
@@ -449,7 +450,8 @@ TypeDesc Geometry::standard_type(AttributeStandard std) const {
   return TypeUnknown;
 }
 
-AttributeElement Geometry::standard_element(AttributeStandard std) const {
+AttributeElement Geometry::standard_element(AttributeStandard std) const
+{
   if (type == Geometry::MESH) {
     switch (std) {
       case ATTR_STD_VERTEX_NORMAL:
@@ -530,8 +532,10 @@ AttributeElement Geometry::standard_element(AttributeStandard std) const {
       case ATTR_STD_UV:
         return ATTR_ELEMENT_VERTEX;
       case ATTR_STD_GENERATED:
-        return  ATTR_ELEMENT_VERTEX;
+        return ATTR_ELEMENT_VERTEX;
       case ATTR_STD_MOTION_VERTEX_POSITION:
+        return ATTR_ELEMENT_VERTEX_MOTION;
+      case ATTR_STD_MOTION_VERTEX_NORMAL:
         return ATTR_ELEMENT_VERTEX_MOTION;
       case ATTR_STD_VERTEX_VELOCITY:
         return ATTR_ELEMENT_VERTEX;


### PR DESCRIPTION
Supporting motion normals for point cloud through the standard attribute.

Disc moving along x, camera along z
Fixed normals (before)
![motion_normals_off](https://user-images.githubusercontent.com/2072636/118854132-845f8f80-b8a2-11eb-88b8-948ee545fe50.PNG)


Changing normals (-1, 0, 0) (0, 1, 0) (1, 0, 0)
![motion_normals_on](https://user-images.githubusercontent.com/2072636/118853815-29c63380-b8a2-11eb-81ee-c6ac8a462768.PNG)


